### PR TITLE
fix(ci): remove redundant test step in CI workflow 🐛

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,6 @@ jobs:
       - name: Download dependencies
         run: make deps
 
-      - name: Run tests
-        run: make test
-
       - name: Run tests with coverage
         run: make test-verbose
 


### PR DESCRIPTION
## Summary

- Remove the redundant `make test` step from CI workflow
- `make test-verbose` already runs the full test suite with `-race`, `-coverprofile`, and `-covermode=atomic`, making `make test` a strict subset
- Halves CI test execution time with no coverage loss

Refs #5

## Test plan

- [x] CI passes on this PR (single test step runs successfully)
- [x] Coverage report still generated in CI output
