### PR TITLE
fix(ci): use bare version for docker image tags 🐛

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -46,12 +46,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        run: make docker-push IMAGE_TAG=${{ needs.release-please.outputs.tag_name }}
+        run: make docker-push IMAGE_TAG=${{ needs.release-please.outputs.version }}
 
       - name: Tag and push latest
-        if: ${{ !contains(needs.release-please.outputs.tag_name, 'alpha') && !contains(needs.release-please.outputs.tag_name, 'beta') }}
+        if: ${{ !contains(needs.release-please.outputs.version, 'alpha') && !contains(needs.release-please.outputs.version, 'beta') }}
         env:
-          IMAGE_TAG: ${{ needs.release-please.outputs.tag_name }}
+          IMAGE_TAG: ${{ needs.release-please.outputs.version }}
         run: |
           docker tag ghcr.io/${{ github.repository }}:$IMAGE_TAG ghcr.io/${{ github.repository }}:latest
           docker push ghcr.io/${{ github.repository }}:latest
@@ -65,5 +65,5 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Pull with:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ghcr.io/klazomenai/jwt-auth-service:${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/${{ github.repository }}:${{ needs.release-please.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Switch Docker image tags from `tag_name` (v-prefixed, e.g. `v0.1.4-alpha.0`) to `version` (bare, e.g. `0.1.4-alpha.0`) in the release workflow
- Aligns with Docker convention (`python:3.11`, `redis:7-alpine`, not `python:v3.11`)
- Also fixes the summary `docker pull` example to show the correct bare version tag

Refs #44

## Test plan

- [x] CI passes (workflow YAML is valid)
- [x] `version` output used in all 4 Docker-related locations (build, condition, env, summary)
- [x] Summary still displays both git tag and version for reference
