### PR TITLE
fix(metrics): implement revoked tokens total metric using redis scan 🐛

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -107,4 +107,13 @@ func (c *Collector) UpdateMetrics() {
 
 	// Update total active tokens
 	ParentTokensActiveTotal.Set(float64(len(configs)))
+
+	// Update revoked token count via Redis SCAN
+	revokedCount, err := c.store.GetRevokedTokenCount(ctx)
+	if err != nil {
+		log.Printf("Warning: Failed to get revoked token count: %v", err)
+		RevokedTokensTotal.Set(0)
+	} else {
+		RevokedTokensTotal.Set(float64(revokedCount))
+	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -31,6 +31,11 @@ func setupTestMetrics(t *testing.T) (*Collector, *storage.RedisStore, *miniredis
 
 	collector := NewCollector(store)
 
+	t.Cleanup(func() {
+		store.Close()
+		mr.Close()
+	})
+
 	return collector, store, mr
 }
 
@@ -53,8 +58,7 @@ func getGaugeVecValue(gv *prometheus.GaugeVec, labels prometheus.Labels) float64
 }
 
 func TestNewCollector(t *testing.T) {
-	collector, _, mr := setupTestMetrics(t)
-	defer mr.Close()
+	collector, _, _ := setupTestMetrics(t)
 
 	if collector == nil {
 		t.Fatal("Expected collector to be created")
@@ -66,8 +70,7 @@ func TestNewCollector(t *testing.T) {
 }
 
 func TestUpdateMetrics_NoConfigs(t *testing.T) {
-	collector, _, mr := setupTestMetrics(t)
-	defer mr.Close()
+	collector, _, _ := setupTestMetrics(t)
 
 	// Update metrics with no configurations
 	collector.UpdateMetrics()
@@ -80,8 +83,7 @@ func TestUpdateMetrics_NoConfigs(t *testing.T) {
 }
 
 func TestUpdateMetrics_WithConfigs(t *testing.T) {
-	collector, store, mr := setupTestMetrics(t)
-	defer mr.Close()
+	collector, store, _ := setupTestMetrics(t)
 
 	// Create test auto-renewal config
 	config := &storage.AutoRenewalConfig{
@@ -139,8 +141,7 @@ func TestUpdateMetrics_WithConfigs(t *testing.T) {
 }
 
 func TestUpdateMetrics_MultipleConfigs(t *testing.T) {
-	collector, store, mr := setupTestMetrics(t)
-	defer mr.Close()
+	collector, store, _ := setupTestMetrics(t)
 
 	ctx := t.Context()
 
@@ -192,8 +193,7 @@ func TestUpdateMetrics_MultipleConfigs(t *testing.T) {
 }
 
 func TestUpdateMetrics_ResetsStaleMetrics(t *testing.T) {
-	collector, store, mr := setupTestMetrics(t)
-	defer mr.Close()
+	collector, store, _ := setupTestMetrics(t)
 
 	ctx := t.Context()
 
@@ -264,6 +264,70 @@ func TestUpdateMetrics_ResetsStaleMetrics(t *testing.T) {
 	value2 := getGaugeVecValue(ParentTokenExpiryTimestamp, labels2)
 	if value2 == 0 {
 		t.Error("Expected new config to be tracked")
+	}
+}
+
+func TestUpdateMetrics_RevokedTokens(t *testing.T) {
+	collector, store, _ := setupTestMetrics(t)
+
+	ctx := t.Context()
+
+	// Before revocation, metric should be 0
+	collector.UpdateMetrics()
+	value := getGaugeValue(RevokedTokensTotal)
+	if value != 0 {
+		t.Errorf("Expected 0 revoked tokens, got %v", value)
+	}
+
+	// Revoke a token
+	if err := store.RevokeToken(ctx, "revoked-jti-1", 1*time.Hour); err != nil {
+		t.Fatalf("Failed to revoke token: %v", err)
+	}
+
+	// After revocation, metric should be 1
+	collector.UpdateMetrics()
+	value = getGaugeValue(RevokedTokensTotal)
+	if value != 1 {
+		t.Errorf("Expected 1 revoked token, got %v", value)
+	}
+}
+
+func TestUpdateMetrics_RevokedTokensMultiple(t *testing.T) {
+	collector, store, _ := setupTestMetrics(t)
+
+	ctx := t.Context()
+
+	// Revoke 3 tokens
+	tokens := []string{"jti-a", "jti-b", "jti-c"}
+	for _, jti := range tokens {
+		if err := store.RevokeToken(ctx, jti, 1*time.Hour); err != nil {
+			t.Fatalf("Failed to revoke token %s: %v", jti, err)
+		}
+	}
+
+	// Metric should reflect all 3
+	collector.UpdateMetrics()
+	value := getGaugeValue(RevokedTokensTotal)
+	if value != 3 {
+		t.Errorf("Expected 3 revoked tokens, got %v", value)
+	}
+}
+
+func TestUpdateMetrics_RedisDown(t *testing.T) {
+	collector, _, mr := setupTestMetrics(t)
+
+	// Set a known non-zero value to verify it gets reset
+	RevokedTokensTotal.Set(99)
+
+	// Close miniredis to simulate Redis failure
+	mr.Close()
+
+	// UpdateMetrics should not panic, and should set revoked total to 0
+	collector.UpdateMetrics()
+
+	value := getGaugeValue(RevokedTokensTotal)
+	if value != 0 {
+		t.Errorf("Expected RevokedTokensTotal to be 0 when Redis is down, got %v", value)
 	}
 }
 

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -38,8 +38,8 @@ type AutoRenewalConfig struct {
 	UserID       string    `json:"user_id"`
 	Network      string    `json:"network"`
 	RateLimit    int       `json:"rate_limit"`
-	ChildExpiry  int64     `json:"child_expiry"`   // Duration in seconds
-	ParentExpiry time.Time `json:"parent_expiry"`  // Absolute expiry time
+	ChildExpiry  int64     `json:"child_expiry"`  // Duration in seconds
+	ParentExpiry time.Time `json:"parent_expiry"` // Absolute expiry time
 	CreatedAt    time.Time `json:"created_at"`
 }
 
@@ -353,6 +353,27 @@ func (s *RedisStore) RevokeChildTokens(ctx context.Context, parentJTI string, tt
 	}
 
 	return len(children), nil
+}
+
+// GetRevokedTokenCount returns the count of revoked tokens using SCAN.
+// This is O(N) but acceptable for alpha workloads (<1000 revocations).
+func (s *RedisStore) GetRevokedTokenCount(ctx context.Context) (int64, error) {
+	var count int64
+	var cursor uint64
+	pattern := revokedTokenPrefix + "*"
+
+	for {
+		keys, nextCursor, err := s.client.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			return 0, fmt.Errorf("failed to scan revoked tokens: %w", err)
+		}
+		count += int64(len(keys))
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+	return count, nil
 }
 
 // Close closes the Redis connection

--- a/pkg/storage/redis_test.go
+++ b/pkg/storage/redis_test.go
@@ -158,23 +158,23 @@ func TestIsTokenRevoked(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		tokenID        string
+		name            string
+		tokenID         string
 		expectedRevoked bool
 	}{
 		{
-			name:           "revoked token",
-			tokenID:        revokedTokenID,
+			name:            "revoked token",
+			tokenID:         revokedTokenID,
 			expectedRevoked: true,
 		},
 		{
-			name:           "non-revoked token",
-			tokenID:        "active-token",
+			name:            "non-revoked token",
+			tokenID:         "active-token",
 			expectedRevoked: false,
 		},
 		{
-			name:           "non-existent token",
-			tokenID:        "non-existent",
+			name:            "non-existent token",
+			tokenID:         "non-existent",
 			expectedRevoked: false,
 		},
 	}
@@ -775,6 +775,92 @@ func TestRevokeChildTokens(t *testing.T) {
 	}
 	if exists != 0 {
 		t.Error("Child tracking set should be deleted after cascade revocation")
+	}
+}
+
+func TestGetRevokedTokenCount(t *testing.T) {
+	store, mr := setupTestRedis(t)
+	defer mr.Close()
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Empty state should return 0
+	count, err := store.GetRevokedTokenCount(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get revoked token count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("Expected 0 revoked tokens, got %d", count)
+	}
+
+	// Revoke 3 tokens
+	tokens := []string{"token-a", "token-b", "token-c"}
+	for _, tokenID := range tokens {
+		if err := store.RevokeToken(ctx, tokenID, 1*time.Hour); err != nil {
+			t.Fatalf("Failed to revoke token: %v", err)
+		}
+	}
+
+	// Count should be 3
+	count, err = store.GetRevokedTokenCount(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get revoked token count: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("Expected 3 revoked tokens, got %d", count)
+	}
+}
+
+func TestGetRevokedTokenCount_AfterExpiry(t *testing.T) {
+	store, mr := setupTestRedis(t)
+	defer mr.Close()
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Revoke 2 tokens with different TTLs
+	if err := store.RevokeToken(ctx, "short-lived", 2*time.Second); err != nil {
+		t.Fatalf("Failed to revoke token: %v", err)
+	}
+	if err := store.RevokeToken(ctx, "long-lived", 1*time.Hour); err != nil {
+		t.Fatalf("Failed to revoke token: %v", err)
+	}
+
+	// Both should be counted
+	count, err := store.GetRevokedTokenCount(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get revoked token count: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("Expected 2 revoked tokens, got %d", count)
+	}
+
+	// Fast-forward past the short TTL
+	mr.FastForward(3 * time.Second)
+
+	// Only the long-lived token should remain
+	count, err = store.GetRevokedTokenCount(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get revoked token count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Expected 1 revoked token after expiry, got %d", count)
+	}
+}
+
+func TestGetRevokedTokenCount_Error(t *testing.T) {
+	store, mr := setupTestRedis(t)
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Close miniredis to force SCAN error
+	mr.Close()
+
+	_, err := store.GetRevokedTokenCount(ctx)
+	if err == nil {
+		t.Fatal("Expected error when Redis is down, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `GetRevokedTokenCount()` method to `RedisStore` using cursor-based SCAN with COUNT hint 100
- Wire into `UpdateMetrics()` to populate the existing `RevokedTokensTotal` gauge on each `/metrics` scrape
- On SCAN failure: log warning, set metric to 0, do not fail the scrape
- `t.Cleanup` in `setupTestMetrics` for proper store/miniredis teardown

Refs #16

## Test plan

- [x] CI passes (all 3 checks)
- [x] Unit test: empty state returns 0, revoke 3 tokens returns 3 (`TestGetRevokedTokenCount`)
- [x] Unit test: TTL expiry reduces count (`TestGetRevokedTokenCount_AfterExpiry`)
- [x] Unit test: closed Redis returns error (`TestGetRevokedTokenCount_Error`)
- [x] Integration test: revoke token, UpdateMetrics, verify gauge == 1 (`TestUpdateMetrics_RevokedTokens`)
- [x] Integration test: revoke 3 tokens, verify gauge == 3 (`TestUpdateMetrics_RevokedTokensMultiple`)
- [x] Integration test: Redis down, UpdateMetrics sets gauge to 0, no panic (`TestUpdateMetrics_RedisDown`)
