### PR TITLE
chore(release): add security type to changelog sections ⚙️

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
     {"type": "perf", "section": "Changed", "hidden": false},
     {"type": "refactor", "section": "Changed", "hidden": false},
     {"type": "revert", "section": "Reverted", "hidden": false},
+    {"type": "security", "section": "Security", "hidden": false},
     {"type": "docs", "section": "Documentation", "hidden": true},
     {"type": "style", "section": "Style", "hidden": true},
     {"type": "chore", "section": "Miscellaneous", "hidden": true},


### PR DESCRIPTION
## Summary

- Add `security` type to `changelog-sections` in release-please config so future `security(...)` commits appear under a visible "Security" section in release notes

## Test plan

- [ ] CI passes
- [ ] Next release with a `security(...)` commit includes a "Security" section in the changelog
