### PR TITLE
feat(api): accept Autonity-Token header for JWT delivery ⛵

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,14 @@ Returns Prometheus-formatted metrics for monitoring token lifecycle:
 
 ```bash
 POST /authorize
-Authorization: Bearer <token>
+Autonity-Token: <token>
 ```
+
+The `Autonity-Token` header carries the raw JWT (no `Bearer` prefix). This avoids conflicts
+with other protocols that use `Authorization: Bearer` for non-JWT tokens on shared gateways.
+
+For backwards compatibility, `Authorization: Bearer <token>` is also accepted. `Autonity-Token`
+takes precedence when both headers are present.
 
 Returns `200 OK` if valid, `401/403` if invalid or revoked.
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ with other protocols that use `Authorization: Bearer` for non-JWT tokens on shar
 For backwards compatibility, `Authorization: Bearer <token>` is also accepted. `Autonity-Token`
 takes precedence when both headers are present.
 
-Returns `200 OK` if valid, `401/403` if invalid or revoked.
+Returns `200 OK` if valid. On error, returns a 4xx status (e.g. `400` for missing claims, `401` for invalid tokens, `403` for revoked tokens).
 
 ## Development
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -403,19 +403,23 @@ func (s *Server) RevokeUserTokens(w http.ResponseWriter, r *http.Request) {
 // Authorize handles external authorization requests from Envoy ext_authz filter
 // This endpoint checks if a JWT token (already validated) has been revoked
 func (s *Server) Authorize(w http.ResponseWriter, r *http.Request) {
-	// Extract JWT from Authorization header
-	authHeader := r.Header.Get("Authorization")
-	if authHeader == "" {
-		s.sendError(w, http.StatusUnauthorized, "Missing Authorization header", "")
-		return
+	// Extract JWT token — prefer Autonity-Token header (RFC 6648 compliant custom header),
+	// fall back to Authorization: Bearer for backwards compatibility during migration.
+	tokenString := r.Header.Get("Autonity-Token")
+	if tokenString == "" {
+		// Backwards compatibility: extract from Authorization: Bearer <token>
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "" {
+			if len(authHeader) > 7 && authHeader[:7] == "Bearer " {
+				tokenString = authHeader[7:]
+			} else {
+				s.sendError(w, http.StatusUnauthorized, "Invalid Authorization header format", "Expected 'Bearer <token>' or use 'Autonity-Token' header")
+				return
+			}
+		}
 	}
-
-	// Extract token from "Bearer <token>" format
-	tokenString := ""
-	if len(authHeader) > 7 && authHeader[:7] == "Bearer " {
-		tokenString = authHeader[7:]
-	} else {
-		s.sendError(w, http.StatusUnauthorized, "Invalid Authorization header format", "Expected 'Bearer <token>'")
+	if tokenString == "" {
+		s.sendError(w, http.StatusUnauthorized, "Missing token", "Provide 'Autonity-Token' header or 'Authorization: Bearer <token>'")
 		return
 	}
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -403,7 +403,7 @@ func (s *Server) RevokeUserTokens(w http.ResponseWriter, r *http.Request) {
 
 // Authorize handles external authorization requests from Envoy/Istio.
 // Validates the JWT signature, checks revocation status (including parent cascade),
-// and returns 200/401/403 accordingly.
+// and returns appropriate HTTP status codes (e.g., 200 on success, 400/401/403 on errors).
 func (s *Server) Authorize(w http.ResponseWriter, r *http.Request) {
 	// Extract JWT token — prefer Autonity-Token header (RFC 6648 compliant custom header),
 	// fall back to Authorization: Bearer for backwards compatibility during migration.

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -407,8 +407,15 @@ func (s *Server) RevokeUserTokens(w http.ResponseWriter, r *http.Request) {
 func (s *Server) Authorize(w http.ResponseWriter, r *http.Request) {
 	// Extract JWT token — prefer Autonity-Token header (RFC 6648 compliant custom header),
 	// fall back to Authorization: Bearer for backwards compatibility during migration.
-	tokenString := strings.TrimSpace(r.Header.Get("Autonity-Token"))
-	if tokenString == "" {
+	// When Autonity-Token is present (even if empty), it is authoritative — no Bearer fallback.
+	var tokenString string
+	if _, ok := r.Header["Autonity-Token"]; ok {
+		tokenString = strings.TrimSpace(r.Header.Get("Autonity-Token"))
+		if tokenString == "" {
+			s.sendError(w, http.StatusUnauthorized, "Empty Autonity-Token header", "")
+			return
+		}
+	} else {
 		// Backwards compatibility: extract from Authorization: Bearer <token>
 		// RFC 9110 §11.1: auth scheme is case-insensitive.
 		authHeader := r.Header.Get("Authorization")

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -408,10 +409,11 @@ func (s *Server) Authorize(w http.ResponseWriter, r *http.Request) {
 	tokenString := r.Header.Get("Autonity-Token")
 	if tokenString == "" {
 		// Backwards compatibility: extract from Authorization: Bearer <token>
+		// RFC 9110 §11.1: auth scheme is case-insensitive.
 		authHeader := r.Header.Get("Authorization")
 		if authHeader != "" {
-			if len(authHeader) > 7 && authHeader[:7] == "Bearer " {
-				tokenString = authHeader[7:]
+			if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
+				tokenString = strings.TrimSpace(authHeader[7:])
 			} else {
 				s.sendError(w, http.StatusUnauthorized, "Invalid Authorization header format", "Expected 'Bearer <token>' or use 'Autonity-Token' header")
 				return

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -401,12 +401,13 @@ func (s *Server) RevokeUserTokens(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// Authorize handles external authorization requests from Envoy ext_authz filter
-// This endpoint checks if a JWT token (already validated) has been revoked
+// Authorize handles external authorization requests from Envoy/Istio.
+// Validates the JWT signature, checks revocation status (including parent cascade),
+// and returns 200/401/403 accordingly.
 func (s *Server) Authorize(w http.ResponseWriter, r *http.Request) {
 	// Extract JWT token — prefer Autonity-Token header (RFC 6648 compliant custom header),
 	// fall back to Authorization: Bearer for backwards compatibility during migration.
-	tokenString := r.Header.Get("Autonity-Token")
+	tokenString := strings.TrimSpace(r.Header.Get("Autonity-Token"))
 	if tokenString == "" {
 		// Backwards compatibility: extract from Authorization: Bearer <token>
 		// RFC 9110 §11.1: auth scheme is case-insensitive.

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -314,8 +314,8 @@ func TestAuthorize_InvalidAutonityTokenBlocksBearerFallback(t *testing.T) {
 
 	server.Authorize(w, req)
 
-	if w.Code == http.StatusOK {
-		t.Errorf("Expected failure when Autonity-Token is invalid even with valid Bearer, got 200")
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected 401 Unauthorized when Autonity-Token is invalid even with valid Bearer, got %d (body: %s)", w.Code, w.Body.String())
 	}
 }
 
@@ -324,7 +324,10 @@ func TestAuthorize_RevokedToken(t *testing.T) {
 	defer mr.Close()
 
 	// Create and revoke a token
-	token, tokenID, _ := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	token, tokenID, err := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
 	ctx := context.Background()
 	server.store.RevokeToken(ctx, tokenID, 1*time.Hour)
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -239,7 +239,28 @@ func TestAuthorize_ValidToken(t *testing.T) {
 	// Create a valid token
 	token, tokenID, _ := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
 
-	// Test authorization
+	// Test authorization with Autonity-Token header (primary)
+	req := httptest.NewRequest("POST", "/authorize", nil)
+	req.Header.Set("Autonity-Token", token)
+	w := httptest.NewRecorder()
+
+	server.Authorize(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200 with Autonity-Token header, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	_ = tokenID // Used to avoid unused variable error
+}
+
+func TestAuthorize_ValidToken_BearerFallback(t *testing.T) {
+	server, mr := setupTestServer(t)
+	defer mr.Close()
+
+	// Create a valid token
+	token, _, _ := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+
+	// Test authorization with Authorization: Bearer (backwards compat)
 	req := httptest.NewRequest("POST", "/authorize", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	w := httptest.NewRecorder()
@@ -247,10 +268,28 @@ func TestAuthorize_ValidToken(t *testing.T) {
 	server.Authorize(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d (body: %s)", w.Code, w.Body.String())
+		t.Errorf("Expected status 200 with Authorization: Bearer fallback, got %d (body: %s)", w.Code, w.Body.String())
 	}
+}
 
-	_ = tokenID // Used to avoid unused variable error
+func TestAuthorize_AutonityTokenTakesPrecedence(t *testing.T) {
+	server, mr := setupTestServer(t)
+	defer mr.Close()
+
+	// Create a valid token and an invalid one
+	validToken, _, _ := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+
+	// Send valid in Autonity-Token, invalid in Authorization
+	req := httptest.NewRequest("POST", "/authorize", nil)
+	req.Header.Set("Autonity-Token", validToken)
+	req.Header.Set("Authorization", "Bearer invalid.token.here")
+	w := httptest.NewRecorder()
+
+	server.Authorize(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected Autonity-Token to take precedence, got %d (body: %s)", w.Code, w.Body.String())
+	}
 }
 
 func TestAuthorize_RevokedToken(t *testing.T) {
@@ -262,9 +301,9 @@ func TestAuthorize_RevokedToken(t *testing.T) {
 	ctx := context.Background()
 	server.store.RevokeToken(ctx, tokenID, 1*time.Hour)
 
-	// Test authorization with revoked token
+	// Test authorization with revoked token via Autonity-Token header
 	req := httptest.NewRequest("POST", "/authorize", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Autonity-Token", token)
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
@@ -280,22 +319,27 @@ func TestAuthorize_InvalidToken(t *testing.T) {
 	defer mr.Close()
 
 	tests := []struct {
-		name           string
-		authHeader     string
-		expectedStatus int
+		name             string
+		autonityToken    string
+		authHeader       string
+		expectedStatus   int
 	}{
 		{
-			name:           "missing authorization header",
-			authHeader:     "",
+			name:           "missing both headers",
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name:           "invalid token format",
+			name:           "invalid autonity-token",
+			autonityToken:  "invalid.token.here",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "invalid bearer token (fallback)",
 			authHeader:     "Bearer invalid.token.here",
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name:           "malformed header",
+			name:           "malformed authorization header",
 			authHeader:     "NotBearer token",
 			expectedStatus: http.StatusUnauthorized,
 		},
@@ -309,6 +353,9 @@ func TestAuthorize_InvalidToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest("POST", "/authorize", nil)
+			if tt.autonityToken != "" {
+				req.Header.Set("Autonity-Token", tt.autonityToken)
+			}
 			if tt.authHeader != "" {
 				req.Header.Set("Authorization", tt.authHeader)
 			}
@@ -335,7 +382,7 @@ func TestAuthorize_SupportedMethods(t *testing.T) {
 	for _, method := range methods {
 		t.Run(method, func(t *testing.T) {
 			req := httptest.NewRequest(method, "/authorize", nil)
-			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Autonity-Token", token)
 			w := httptest.NewRecorder()
 
 			server.Authorize(w, req)
@@ -777,7 +824,7 @@ func TestAuthorize_ChildWithRevokedParent(t *testing.T) {
 
 	// Authorize child token before revoking parent — should succeed
 	req := httptest.NewRequest("POST", "/authorize", nil)
-	req.Header.Set("Authorization", "Bearer "+childToken)
+	req.Header.Set("Autonity-Token", childToken)
 	w := httptest.NewRecorder()
 	server.Authorize(w, req)
 
@@ -793,7 +840,7 @@ func TestAuthorize_ChildWithRevokedParent(t *testing.T) {
 
 	// Authorize child token after revoking parent — should fail
 	req2 := httptest.NewRequest("POST", "/authorize", nil)
-	req2.Header.Set("Authorization", "Bearer "+childToken)
+	req2.Header.Set("Autonity-Token", childToken)
 	w2 := httptest.NewRecorder()
 	server.Authorize(w2, req2)
 
@@ -820,7 +867,7 @@ func TestAuthorize_ChildWithValidParent(t *testing.T) {
 
 	// Authorize child token — should succeed (parent not revoked)
 	req := httptest.NewRequest("POST", "/authorize", nil)
-	req.Header.Set("Authorization", "Bearer "+childToken)
+	req.Header.Set("Autonity-Token", childToken)
 	w := httptest.NewRecorder()
 	server.Authorize(w, req)
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -237,7 +237,7 @@ func TestAuthorize_ValidToken(t *testing.T) {
 	defer mr.Close()
 
 	// Create a valid token
-	token, tokenID, _ := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	token, _, _ := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
 
 	// Test authorization with Autonity-Token header (primary)
 	req := httptest.NewRequest("POST", "/authorize", nil)
@@ -249,8 +249,6 @@ func TestAuthorize_ValidToken(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status 200 with Autonity-Token header, got %d (body: %s)", w.Code, w.Body.String())
 	}
-
-	_ = tokenID // Used to avoid unused variable error
 }
 
 func TestAuthorize_ValidToken_BearerFallback(t *testing.T) {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -351,6 +351,7 @@ func TestAuthorize_InvalidToken(t *testing.T) {
 	tests := []struct {
 		name             string
 		autonityToken    string
+		setAutonityToken bool // explicitly set header even if empty
 		authHeader       string
 		expectedStatus   int
 	}{
@@ -362,6 +363,13 @@ func TestAuthorize_InvalidToken(t *testing.T) {
 			name:           "invalid autonity-token",
 			autonityToken:  "invalid.token.here",
 			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:             "empty autonity-token blocks bearer fallback",
+			setAutonityToken: true,
+			autonityToken:    "",
+			authHeader:       "Bearer valid.looking.token",
+			expectedStatus:   http.StatusUnauthorized,
 		},
 		{
 			name:           "invalid bearer token (fallback)",
@@ -383,7 +391,7 @@ func TestAuthorize_InvalidToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest("POST", "/authorize", nil)
-			if tt.autonityToken != "" {
+			if tt.autonityToken != "" || tt.setAutonityToken {
 				req.Header.Set("Autonity-Token", tt.autonityToken)
 			}
 			if tt.authHeader != "" {

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -236,8 +236,10 @@ func TestAuthorize_ValidToken(t *testing.T) {
 	server, mr := setupTestServer(t)
 	defer mr.Close()
 
-	// Create a valid token
-	token, _, _ := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	token, _, err := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
 
 	// Test authorization with Autonity-Token header (primary)
 	req := httptest.NewRequest("POST", "/authorize", nil)
@@ -255,8 +257,10 @@ func TestAuthorize_ValidToken_BearerFallback(t *testing.T) {
 	server, mr := setupTestServer(t)
 	defer mr.Close()
 
-	// Create a valid token
-	token, _, _ := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	token, _, err := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
 
 	// Test authorization with Authorization: Bearer (backwards compat)
 	req := httptest.NewRequest("POST", "/authorize", nil)
@@ -274,8 +278,10 @@ func TestAuthorize_AutonityTokenTakesPrecedence(t *testing.T) {
 	server, mr := setupTestServer(t)
 	defer mr.Close()
 
-	// Create a valid token and an invalid one
-	validToken, _, _ := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	validToken, _, err := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
 
 	// Send valid in Autonity-Token, invalid in Authorization
 	req := httptest.NewRequest("POST", "/authorize", nil)

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -296,6 +296,29 @@ func TestAuthorize_AutonityTokenTakesPrecedence(t *testing.T) {
 	}
 }
 
+func TestAuthorize_InvalidAutonityTokenBlocksBearerFallback(t *testing.T) {
+	server, mr := setupTestServer(t)
+	defer mr.Close()
+
+	validToken, _, err := server.jwtService.CreateToken("alice", "devnet", 100, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
+
+	// Send invalid Autonity-Token and valid Authorization: Bearer —
+	// Autonity-Token is authoritative when present, no fallback.
+	req := httptest.NewRequest("POST", "/authorize", nil)
+	req.Header.Set("Autonity-Token", "invalid.token.here")
+	req.Header.Set("Authorization", "Bearer "+validToken)
+	w := httptest.NewRecorder()
+
+	server.Authorize(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Errorf("Expected failure when Autonity-Token is invalid even with valid Bearer, got 200")
+	}
+}
+
 func TestAuthorize_RevokedToken(t *testing.T) {
 	server, mr := setupTestServer(t)
 	defer mr.Close()


### PR DESCRIPTION
## Summary

- `/authorize` endpoint now reads JWT from `Autonity-Token` header first, falling back to `Authorization: Bearer` for backwards compatibility
- `Autonity-Token` is an RFC 6648 compliant custom header (no `X-` prefix) carrying the raw JWT without a Bearer scheme prefix
- Prevents conflicts with protocols that use `Authorization: Bearer` for non-JWT opaque tokens on shared gateways

## Token format

```
Autonity-Token: eyJhbGciOiJSUzI1NiIs...
```

Raw JWT, no scheme prefix. `Autonity-Token` takes precedence when both headers are present.

## Test plan

- [x] `TestAuthorize_ValidToken` — primary header path
- [x] `TestAuthorize_ValidToken_BearerFallback` — backwards compat
- [x] `TestAuthorize_AutonityTokenTakesPrecedence` — both headers, Autonity-Token wins
- [x] `TestAuthorize_InvalidToken` — updated table covers both header paths
- [x] `TestAuthorize_RevokedToken` — uses new header
- [x] `TestAuthorize_SupportedMethods` — POST/GET/HEAD with new header
- [x] `TestAuthorize_ChildWithRevokedParent` — uses new header
- [x] `TestAuthorize_ChildWithValidParent` — uses new header
- [x] All existing tests pass (pre-existing `pkg/metrics` failure unrelated — requires Go 1.24+ `t.Context()`)

Refs #63
